### PR TITLE
Fix Trusty drivers error messages

### DIFF
--- a/drivers/trusty/trusty-x86_64.c
+++ b/drivers/trusty/trusty-x86_64.c
@@ -73,6 +73,7 @@ struct trusty_x86_64_irq_s {
 		.vector = 0x21,
 		.action = &tmp_action,
 	},
+*/
 	{
 		.irq = 3,
 		.vector = 0x22,
@@ -83,21 +84,22 @@ struct trusty_x86_64_irq_s {
 		.vector = 0x23,
 		.action = &tmp_action,
 	},
-*/
 };
 
-static long trusty_smc8_binder(void *args)
-{
-	struct smc_ret8 *para = (struct smc_ret8*)args;
+struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
+			    unsigned long r2, unsigned long r3,
+			    unsigned long r4, unsigned long r5,
+			    unsigned long r6, unsigned long r7) {
+	struct smc_ret8 para = {r0, r1, r2, r3, r4, r5, r6, r7};
 	register unsigned long smc_id asm("rax") = IKGT_SMC_HC_ID;
-	register unsigned long arg0 asm("rdi") = para->r0;
-	register unsigned long arg1 asm("rsi") = para->r1;
-	register unsigned long arg2 asm("rdx") = para->r2;
-	register unsigned long arg3 asm("rcx") = para->r3;
-	register unsigned long arg4 asm("r8")  = para->r4;
-	register unsigned long arg5 asm("r9")  = para->r5;
-	register unsigned long arg6 asm("r10") = para->r6;
-	register unsigned long arg7 asm("r11") = para->r7;
+	register unsigned long arg0 asm("rdi") = para.r0;
+	register unsigned long arg1 asm("rsi") = para.r1;
+	register unsigned long arg2 asm("rdx") = para.r2;
+	register unsigned long arg3 asm("rcx") = para.r3;
+	register unsigned long arg4 asm("r8")  = para.r4;
+	register unsigned long arg5 asm("r9")  = para.r5;
+	register unsigned long arg6 asm("r10") = para.r6;
+	register unsigned long arg7 asm("r11") = para.r7;
 
 	__asm__ __volatile__ (
 			"vmcall\n\r"
@@ -107,25 +109,14 @@ static long trusty_smc8_binder(void *args)
 				"r" (arg4), "r" (arg5), "r" (arg6), "r" (arg7)
 			: "memory");
 
-	para->r0 = arg0;
-	para->r1 = arg1;
-	para->r2 = arg2;
-	para->r3 = arg3;
-	para->r4 = arg4;
-	para->r5 = arg5;
-	para->r6 = arg6;
-	para->r7 = arg7;
-
-	return 0;
-}
-
-struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
-			    unsigned long r2, unsigned long r3,
-			    unsigned long r4, unsigned long r5,
-			    unsigned long r6, unsigned long r7) {
-	struct smc_ret8 para = {r0, r1, r2, r3, r4, r5, r6, r7};
-
-	work_on_cpu(0, trusty_smc8_binder, (void *)&para);
+	para.r0 = arg0;
+	para.r1 = arg1;
+	para.r2 = arg2;
+	para.r3 = arg3;
+	para.r4 = arg4;
+	para.r5 = arg5;
+	para.r6 = arg6;
+	para.r7 = arg7;
 
 	return para;
 }

--- a/drivers/trusty/trusty-x86_64.c
+++ b/drivers/trusty/trusty-x86_64.c
@@ -13,6 +13,7 @@
 
 #define IKGT_SMC_HC_ID 0x74727500
 
+#ifdef TRUSTY_X86_OWNS_INTR
 static irqreturn_t stub_action(int cpl, void *dev_id)
 {
 	return IRQ_NONE;
@@ -67,13 +68,11 @@ struct trusty_x86_64_irq_s {
  * Comment out all IRQs which planed to be reserved, since CIV design is
  * different from Google Trusty IA solution design.
  */
-/*
 	{
 		.irq = 1,
 		.vector = 0x21,
 		.action = &tmp_action,
 	},
-*/
 	{
 		.irq = 3,
 		.vector = 0x22,
@@ -85,6 +84,7 @@ struct trusty_x86_64_irq_s {
 		.action = &tmp_action,
 	},
 };
+#endif
 
 struct smc_ret8 trusty_smc8(unsigned long r0, unsigned long r1,
 			    unsigned long r2, unsigned long r3,
@@ -182,6 +182,7 @@ static void __exit trusty_x86_64_driver_exit(void)
 	platform_driver_unregister(&trusty_x86_64_driver);
 }
 
+#ifdef TRUSTY_X86_OWNS_INTR
 int trusty_x86_64_release_reserved_vector(unsigned int vector)
 {
 	int idx;
@@ -243,6 +244,7 @@ static int __init trusty_x86_64_irq_init(void)
 }
 
 core_initcall(trusty_x86_64_irq_init);
+#endif
 
 subsys_initcall(trusty_x86_64_driver_init);
 module_exit(trusty_x86_64_driver_exit);


### PR DESCRIPTION
Binding all SMC to CPU 0.
Remove Trusty interrupt related stuffs.