### PR TITLE
Delete dummy tcp_default_init_rwnd in kernel

### DIFF
--- a/include/net/netns/ipv4.h
+++ b/include/net/netns/ipv4.h
@@ -115,7 +115,6 @@ struct netns_ipv4 {
 #ifdef CONFIG_NET_L3_MASTER_DEV
 	int sysctl_tcp_l3mdev_accept;
 #endif
-	int sysctl_tcp_default_init_rwnd;
 	int sysctl_tcp_mtu_probing;
 	int sysctl_tcp_mtu_probe_floor;
 	int sysctl_tcp_base_mss;

--- a/net/ipv4/sysctl_net_ipv4.c
+++ b/net/ipv4/sysctl_net_ipv4.c
@@ -220,14 +220,6 @@ static int ipv4_fwd_update_priority(struct ctl_table *table, int write,
 	return ret;
 }
 
-/* The current kernel does not rely on this value so we do nothing here */
-static int proc_tcp_default_init_rwnd(struct ctl_table *ctl, int write,
-				      void __user *buffer,
-				      size_t *lenp, loff_t *ppos)
-{
-	return proc_dointvec(ctl, write, buffer, lenp, ppos);
-}
-
 static int proc_tcp_congestion_control(struct ctl_table *ctl, int write,
 				       void __user *buffer, size_t *lenp, loff_t *ppos)
 {
@@ -1322,13 +1314,6 @@ static struct ctl_table ipv4_net_table[] = {
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec_minmax,
 		.extra1		= SYSCTL_ONE
-	},
-	{
-		.procname       = "tcp_default_init_rwnd",
-		.data           = &init_net.ipv4.sysctl_tcp_default_init_rwnd,
-		.maxlen         = sizeof(int),
-		.mode           = 0644,
-		.proc_handler   = proc_tcp_default_init_rwnd
 	},
 	{ }
 };


### PR DESCRIPTION
Revert "CHROMIUM: net: Add per-netns dummy tcp_default_init_rwnd"
This reverts commit 6867335e75502aeb6ff18b5d4cee2a31d404272f.

Delete this file to pass testTcpCwndSize in
vts_kernel_net_tests#vts_kernel_net_tests
For Linux kernel 4.19 and above, tcp_default_init_rwnd is removed
from kernel.

The previous commit added this dummy file to pass CTS test
android.permission.cts.FileSystemPermissionTest#
testTcpDefaultRwndSane
Becasue in this CTS test, it checks the existence of file
tcp_default_init_rwnd. But
commit dd4c3424d53a724a497a23600cae04c741044858: "Read access to
/proc/net is no longer allowed" has removed the checking of
tcp_default_init_rwnd existence. So it is safe to revet
6867335e75502aeb6ff18b5d4cee2a31d404272f.

Change-Id: Ibc26632acdff22126554daf26a90aeaac0a5e338
Tracked-On: OAM-96177
Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>