### PR TITLE
x86/power: fix S3 resume issue when LTO enabled

### DIFF
--- a/arch/x86/power/Makefile
+++ b/arch/x86/power/Makefile
@@ -6,5 +6,10 @@ OBJECT_FILES_NON_STANDARD_hibernate_asm_$(BITS).o := y
 nostackp := $(call cc-option, -fno-stack-protector)
 CFLAGS_cpu.o	:= $(nostackp)
 
+# When LTO enabled, the stack-protector code fragment would be still built
+# into object file. This would trigger TRIPLE_FAULT when resume from S3.
+# So here disable LTO to make resume successful.
+CFLAGS_cpu.o	+= -fno-lto -fvisibility=default -fno-sanitize=cfi
+
 obj-$(CONFIG_PM_SLEEP)		+= cpu.o
 obj-$(CONFIG_HIBERNATION)	+= hibernate_$(BITS).o hibernate_asm_$(BITS).o hibernate.o


### PR DESCRIPTION
When LTO enabled, the stack-protector code fragment would be
still built into object file. This would trigger TRIPLE_FAULT
when resume from S3. So here disable LTO to make resume
successful.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>