### PR TITLE
Revert workarounds done to address suspend/resume reset issue

### DIFF
--- a/arch/x86/power/Makefile
+++ b/arch/x86/power/Makefile
@@ -4,7 +4,7 @@ OBJECT_FILES_NON_STANDARD_hibernate_asm_$(BITS).o := y
 # __restore_processor_state() restores %gs after S3 resume and so should not
 # itself be stack-protected
 nostackp := $(call cc-option, -fno-stack-protector)
-CFLAGS_cpu.o   := $(nostackp)
+CFLAGS_cpu.o	:= $(nostackp)
 
 obj-$(CONFIG_PM_SLEEP)		+= cpu.o
 obj-$(CONFIG_HIBERNATION)	+= hibernate_$(BITS).o hibernate_asm_$(BITS).o hibernate.o

--- a/arch/x86/power/cpu.c
+++ b/arch/x86/power/cpu.c
@@ -191,7 +191,7 @@ static void fix_processor_context(void)
  * The asm code that gets us here will have restored a usable GDT, although
  * it will be pointing to the wrong alias.
  */
-static void noinline notrace __restore_processor_state(struct saved_context *ctxt)
+static void notrace __restore_processor_state(struct saved_context *ctxt)
 {
 	if (ctxt->misc_enable_saved)
 		wrmsrl(MSR_IA32_MISC_ENABLE, ctxt->misc_enable);
@@ -268,19 +268,6 @@ static void noinline notrace __restore_processor_state(struct saved_context *ctx
 /* Needed by apm.c */
 void notrace restore_processor_state(void)
 {
-#ifdef __clang__
-	// The following code snippet is copied from __restore_processor_state.
-	// Its purpose is to prepare GS segment before the function is called.
-	// Since the function is compiled with SCS on, it will use GS at its
-	// entry.
-	// TODO: Hack to be removed later when compiler bug is fixed.
-#ifdef CONFIG_X86_64
-	wrmsrl(MSR_GS_BASE, saved_context.kernelmode_gs_base);
-#else
-	loadsegment(fs, __KERNEL_PERCPU);
-	loadsegment(gs, __KERNEL_STACK_CANARY);
-#endif
-#endif
 	__restore_processor_state(&saved_context);
 }
 #ifdef CONFIG_X86_32


### PR DESCRIPTION
In order to address suspend/resume instability, clang
version is updated to 12.0.3. With clang version updated
to 12.0.3, workarounds are reverted.

Tracked-On: OAM-96701
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>